### PR TITLE
Fix `knacknuss` js newline error

### DIFF
--- a/js/knacknuss.js
+++ b/js/knacknuss.js
@@ -438,7 +438,7 @@
     e2 = document.getElementById("outputTxt");
     e = clearAllChilds("inputTxt");
     if (e2.innerText) {
-      e.value = e2.innerText;
+      e.value = e2.innerText.replaceAll('\n','');
     } else {
       e.value = e2.textContent;
     }


### PR DESCRIPTION
Hier hat sich (evtl mit der Zeit) ein Fehler eingeschlichen. Und zwar wird, wenn man hier https://mgje.github.io/Crypto/exp7/ links oben auf "Neue" klickt, der Text falsch dargestellt, nämlich mit zeilenumbruch nach jedem zeichen.

Ich habe das mal notdürftig gefixt. (Habe aufgegeben, die konkrete Ursache zu finden und einfach ein replace genutzt). Habe auch das CoffeeScript nicht angefasst, weil ich mich da nicht einarbeiten wollte. Auf meinem Fork funktioniert es jetzt damit (für ein merge des pull requests wäre aber zumindest letzteres wohl nötig, aber das mögest du entscheiden :) )